### PR TITLE
Extract Route Generator Logic Into Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Deprecate setting `babdev_pagerfanta.exceptions_strategy.out_of_range_page` and `babdev_pagerfanta.exceptions_strategy.not_valid_current_page` configuration options to any value, as of 3.0 they must be either "to_http_not_found" (default) or "custom"
 - Removed the dependency to TwigBundle and made Twig an optional dependency
 - Made the Symfony Translation component an optional dependency
+- Extracted the logic for building the route generator used by the Twig extension into `BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorFactoryInterface` and `BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorInterface` with default implementations for the existing generator
 
 ## 2.1.0 (2020-01-29)
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ Note that the page parameter *MUST* be wrapped in brackets (i.e. `[other_page]`)
 
 See the [Pagerfanta documentation](https://github.com/whiteoctober/Pagerfanta) for the list of supported options.
 
+## Generating Paginated Routes
+
+When rendering a Pagerfanta view, a route generator callable is required to generate the URLs for each item in the pagination list. As of BabDevPagerfantaBundle 2.2, the route generator can be customized for use within your application if you need to adjust the routing logic.
+
+The route generators are defined by two interfaces, with their default implementations noted below:
+
+- `BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorInterface` - The class type that is used to generate routes
+    - `BabDev\PagerfantaBundle\RouteGenerator\RouterAwareRouteGenerator` is used by default, which uses the Symfony Routing component to generate routes
+- `BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorFactoryInterface` - A factory service that is used to generate a `RouteGeneratorInterface` at runtime
+    - `BabDev\PagerfantaBundle\RouteGenerator\RequestAwareRouteGeneratorFactory` is used by default, which uses the `Request` object to attempt to set the default route name and route parameters, this creates a `RouterAwareRouteGenerator`
+
+The Twig integration uses a `BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorFactoryInterface` instance to create the route generator used when rendering a Pagerfanta view.
+
+The `pagerfanta.route_generator_factory` service is available for use in your application if you need to create a route generator. You may use a compiler pass to change this service to any class meeting the interface requirements.
+
 ## Available Views
 
 ### Default Views

--- a/Resources/config/pagerfanta.xml
+++ b/Resources/config/pagerfanta.xml
@@ -14,6 +14,13 @@
             <!-- conditionally tagged based on the bundle configuration -->
         </service>
 
+        <!-- Route Generator Factory -->
+        <service id="pagerfanta.route_generator_factory" class="BabDev\PagerfantaBundle\RouteGenerator\RequestAwareRouteGeneratorFactory">
+            <argument type="service" id="router" />
+            <argument type="service" id="request_stack" />
+        </service>
+        <service id="BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorFactoryInterface" alias="pagerfanta.route_generator_factory" />
+
         <!-- Twig Extension -->
         <service id="pagerfanta.twig_extension" class="BabDev\PagerfantaBundle\Twig\PagerfantaExtension" public="false">
             <tag name="twig.extension" />

--- a/Resources/config/pagerfanta.xml
+++ b/Resources/config/pagerfanta.xml
@@ -30,8 +30,7 @@
         <service id="pagerfanta.twig_runtime" class="BabDev\PagerfantaBundle\Twig\PagerfantaRuntime" public="false">
             <argument>%babdev_pagerfanta.default_view%</argument>
             <argument type="service" id="pagerfanta.view_factory" />
-            <argument type="service" id="router" />
-            <argument type="service" id="request_stack" />
+            <argument type="service" id="pagerfanta.route_generator_factory" />
             <tag name="twig.runtime" />
         </service>
 

--- a/RouteGenerator/RequestAwareRouteGeneratorFactory.php
+++ b/RouteGenerator/RequestAwareRouteGeneratorFactory.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\RouteGenerator;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class RequestAwareRouteGeneratorFactory implements RouteGeneratorFactoryInterface
+{
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $router;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(UrlGeneratorInterface $router, RequestStack $requestStack)
+    {
+        $this->router = $router;
+        $this->requestStack = $requestStack;
+    }
+
+    public function create(array $options = []): RouteGeneratorInterface
+    {
+        $options = array_replace(
+            [
+                'routeName' => null,
+                'routeParams' => [],
+                'pageParameter' => '[page]',
+                'omitFirstPage' => false,
+            ],
+            $options
+        );
+
+        if (null === $options['routeName']) {
+            $request = $this->getRequest();
+
+            if (null !== $this->requestStack->getParentRequest()) {
+                throw new \RuntimeException('The request aware route generator can not guess the route when used in a sub-request, pass the "routeName" option to use this generator.');
+            }
+
+            $options['routeName'] = $request->attributes->get('_route');
+
+            // Make sure we read the route parameters from the passed option array
+            $defaultRouteParams = array_merge($request->query->all(), $request->attributes->get('_route_params', []));
+
+            $options['routeParams'] = array_merge($defaultRouteParams, $options['routeParams']);
+        }
+
+        return new RouterAwareRouteGenerator($this->router, $options);
+    }
+
+    private function getRequest(): ?Request
+    {
+        return $this->requestStack->getCurrentRequest();
+    }
+}

--- a/RouteGenerator/RouteGeneratorDecorator.php
+++ b/RouteGenerator/RouteGeneratorDecorator.php
@@ -2,7 +2,7 @@
 
 namespace BabDev\PagerfantaBundle\RouteGenerator;
 
-final class RouteGeneratorDecorator
+final class RouteGeneratorDecorator implements RouteGeneratorInterface
 {
     /**
      * @var callable

--- a/RouteGenerator/RouteGeneratorFactoryInterface.php
+++ b/RouteGenerator/RouteGeneratorFactoryInterface.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\RouteGenerator;
+
+interface RouteGeneratorFactoryInterface
+{
+    public function create(array $options = []): RouteGeneratorInterface;
+}

--- a/RouteGenerator/RouteGeneratorInterface.php
+++ b/RouteGenerator/RouteGeneratorInterface.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\RouteGenerator;
+
+interface RouteGeneratorInterface
+{
+    /**
+     * Generates the URL for a page item in a paginator
+     *
+     * @return string The page URL
+     */
+    public function __invoke(int $page): string;
+}

--- a/RouteGenerator/RouterAwareRouteGenerator.php
+++ b/RouteGenerator/RouterAwareRouteGenerator.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\RouteGenerator;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class RouterAwareRouteGenerator implements RouteGeneratorInterface
+{
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $router;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(UrlGeneratorInterface $router, array $options)
+    {
+        $this->router = $router;
+        $this->options = $this->resolveOptions($options);
+    }
+
+    public function __invoke(int $page): string
+    {
+        $pagePropertyPath = new PropertyPath($this->options['pageParameter']);
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        if ($this->options['omitFirstPage']) {
+            $propertyAccessor->setValue($this->options['routeParams'], $pagePropertyPath, $page > 1 ? $page : null);
+        } else {
+            $propertyAccessor->setValue($this->options['routeParams'], $pagePropertyPath, $page);
+        }
+
+        return $this->router->generate($this->options['routeName'], $this->options['routeParams']);
+    }
+
+    private function resolveOptions(array $options): array
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver->setRequired(
+            [
+                'routeName',
+            ]
+        );
+
+        $resolver->setDefaults(
+            [
+                'routeParams' => [],
+                'pageParameter' => '[page]',
+                'omitFirstPage' => false,
+            ]
+        );
+
+        $resolver->setAllowedTypes('routeName', 'string');
+        $resolver->setAllowedTypes('routeParams', 'array');
+        $resolver->setAllowedTypes('pageParameter', 'string');
+        $resolver->setAllowedTypes('omitFirstPage', 'boolean');
+
+        return $resolver->resolve($options);
+    }
+}

--- a/Tests/RouteGenerator/RequestAwareRouteGeneratorFactoryTest.php
+++ b/Tests/RouteGenerator/RequestAwareRouteGeneratorFactoryTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\Tests\RouteGenerator;
+
+use BabDev\PagerfantaBundle\RouteGenerator\RequestAwareRouteGeneratorFactory;
+use BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class RequestAwareRouteGeneratorFactoryTest extends TestCase
+{
+    /**
+     * @var MockObject|UrlGeneratorInterface
+     */
+    private $router;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var RequestAwareRouteGeneratorFactory
+     */
+    private $factory;
+
+    protected function setUp(): void
+    {
+        $this->router = $this->createMock(UrlGeneratorInterface::class);
+        $this->requestStack = new RequestStack();
+
+        $this->factory = new RequestAwareRouteGeneratorFactory(
+            $this->router,
+            $this->requestStack
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        do {
+            $request = $this->requestStack->pop();
+        } while (null !== $request);
+    }
+
+    public function testTheGeneratorIsCreatedWhenResolvingTheRouteNameFromTheRequest(): void
+    {
+        $request = Request::create('/');
+        $request->attributes->set('_route', 'pagerfanta_view');
+        $request->attributes->set('_route_params', []);
+
+        $this->requestStack->push($request);
+
+        $this->assertInstanceOf(
+            RouteGeneratorInterface::class,
+            $this->factory->create()
+        );
+    }
+
+    public function testTheGeneratorIsCreatedWhenGivenARouteNameDuringASubrequest(): void
+    {
+        $masterRequest = Request::create('/');
+        $masterRequest->attributes->set('_route', 'pagerfanta_view');
+        $masterRequest->attributes->set('_route_params', []);
+
+        $subRequest = Request::create('/_internal');
+
+        $this->requestStack->push($masterRequest);
+        $this->requestStack->push($subRequest);
+
+        $this->assertInstanceOf(
+            RouteGeneratorInterface::class,
+            $this->factory->create(['routeName' => 'pagerfanta_view'])
+        );
+    }
+
+    public function testTheGeneratorIsNotCreatedWhenARouteNameIsNotGivenDuringASubrequest(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The request aware route generator can not guess the route when used in a sub-request, pass the "routeName" option to use this generator.');
+
+        $masterRequest = Request::create('/');
+        $masterRequest->attributes->set('_route', 'pagerfanta_view');
+        $masterRequest->attributes->set('_route_params', []);
+
+        $subRequest = Request::create('/_internal');
+
+        $this->requestStack->push($masterRequest);
+        $this->requestStack->push($subRequest);
+
+        $this->factory->create();
+    }
+}

--- a/Tests/RouteGenerator/RouterAwareRouteGeneratorTest.php
+++ b/Tests/RouteGenerator/RouterAwareRouteGeneratorTest.php
@@ -3,8 +3,8 @@
 namespace BabDev\PagerfantaBundle\Tests\RouteGenerator;
 
 use BabDev\PagerfantaBundle\RouteGenerator\RouterAwareRouteGenerator;
+use Pagerfanta\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -60,7 +60,7 @@ final class RouterAwareRouteGeneratorTest extends TestCase
 
     public function testARouteIsNotGeneratedWhenTheRouteNameParameterIsMissing(): void
     {
-        $this->expectException(MissingOptionsException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $generator = new RouterAwareRouteGenerator(
             $this->createRouter(),

--- a/Tests/RouteGenerator/RouterAwareRouteGeneratorTest.php
+++ b/Tests/RouteGenerator/RouterAwareRouteGeneratorTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\Tests\RouteGenerator;
+
+use BabDev\PagerfantaBundle\RouteGenerator\RouterAwareRouteGenerator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+final class RouterAwareRouteGeneratorTest extends TestCase
+{
+    private function createRouter(): UrlGeneratorInterface
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('pagerfanta_view', new Route('/pagerfanta-view'));
+
+        return new UrlGenerator($routeCollection, new RequestContext());
+    }
+
+    public function testARouteIsGeneratedWithEmptyOptions(): void
+    {
+        $generator = new RouterAwareRouteGenerator($this->createRouter(), ['routeName' => 'pagerfanta_view']);
+
+        $this->assertSame('/pagerfanta-view?page=1', $generator(1));
+    }
+
+    public function testARouteIsGeneratedWithFirstPageOmitted(): void
+    {
+        $generator = new RouterAwareRouteGenerator(
+            $this->createRouter(),
+            ['routeName' => 'pagerfanta_view', 'omitFirstPage' => true]
+        );
+
+        $this->assertSame('/pagerfanta-view', $generator(1));
+    }
+
+    public function testARouteIsGeneratedWithACustomPageParameter(): void
+    {
+        $generator = new RouterAwareRouteGenerator(
+            $this->createRouter(),
+            ['routeName' => 'pagerfanta_view', 'pageParameter' => '[custom_page]']
+        );
+
+        $this->assertSame('/pagerfanta-view?custom_page=1', $generator(1));
+    }
+
+    public function testARouteIsGeneratedWithAdditionalParameters(): void
+    {
+        $generator = new RouterAwareRouteGenerator(
+            $this->createRouter(),
+            ['routeName' => 'pagerfanta_view', 'routeParams' => ['hello' => 'world']]
+        );
+
+        $this->assertSame('/pagerfanta-view?hello=world&page=1', $generator(1));
+    }
+
+    public function testARouteIsNotGeneratedWhenTheRouteNameParameterIsMissing(): void
+    {
+        $this->expectException(MissingOptionsException::class);
+
+        $generator = new RouterAwareRouteGenerator(
+            $this->createRouter(),
+            ['routeParams' => ['hello' => 'world']]
+        );
+
+        $generator(1);
+    }
+}

--- a/Tests/Twig/PagerfantaRuntimeTest.php
+++ b/Tests/Twig/PagerfantaRuntimeTest.php
@@ -2,6 +2,8 @@
 
 namespace BabDev\PagerfantaBundle\Tests\Twig;
 
+use BabDev\PagerfantaBundle\RouteGenerator\RequestAwareRouteGeneratorFactory;
+use BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorFactoryInterface;
 use BabDev\PagerfantaBundle\Twig\PagerfantaRuntime;
 use Pagerfanta\Adapter\FixedAdapter;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
@@ -33,6 +35,11 @@ final class PagerfantaRuntimeTest extends TestCase
     private $requestStack;
 
     /**
+     * @var RouteGeneratorFactoryInterface
+     */
+    private $routeGeneratorFactory;
+
+    /**
      * @var PagerfantaRuntime
      */
     private $extension;
@@ -46,11 +53,12 @@ final class PagerfantaRuntimeTest extends TestCase
 
         $this->requestStack = new RequestStack();
 
+        $this->routeGeneratorFactory = $this->createRouteGeneratorFactory();
+
         $this->extension = new PagerfantaRuntime(
             'default',
             $this->viewFactory,
-            $this->router,
-            $this->requestStack
+            $this->routeGeneratorFactory
         );
     }
 
@@ -84,6 +92,14 @@ final class PagerfantaRuntimeTest extends TestCase
             });
 
         return $router;
+    }
+
+    private function createRouteGeneratorFactory(): RouteGeneratorFactoryInterface
+    {
+        return new RequestAwareRouteGeneratorFactory(
+            $this->router,
+            $this->requestStack
+        );
     }
 
     private function createPagerfanta(): Pagerfanta
@@ -219,23 +235,6 @@ final class PagerfantaRuntimeTest extends TestCase
     <a href="/my-page?foo%5Bpage%5D=2" rel="next">Next</a>
 </nav>'
         );
-    }
-
-    public function testTheDefaultPagerfantaViewIsNotRenderedWhenASubrequestIsActiveAndARouteNameIsNotSpecified(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The Twig functions of BabDevPagerfantaBundle can not guess the route when used in a sub-request, pass the "routeName" option to use the pager.');
-
-        $masterRequest = Request::create('/');
-        $masterRequest->attributes->set('_route', 'pagerfanta_view');
-        $masterRequest->attributes->set('_route_params', []);
-
-        $subRequest = Request::create('/_internal');
-
-        $this->requestStack->push($masterRequest);
-        $this->requestStack->push($subRequest);
-
-        $this->extension->renderPagerfanta($this->createPagerfanta());
     }
 
     public function testTheDefaultPagerfantaViewIsNotRenderedWhenAnInvalidTypeIsGivenForTheViewNameArgument(): void

--- a/Tests/View/TwigViewIntegrationTest.php
+++ b/Tests/View/TwigViewIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace BabDev\PagerfantaBundle\Tests\View;
 
+use BabDev\PagerfantaBundle\RouteGenerator\RequestAwareRouteGeneratorFactory;
 use BabDev\PagerfantaBundle\Twig\PagerfantaExtension;
 use BabDev\PagerfantaBundle\Twig\PagerfantaRuntime;
 use BabDev\PagerfantaBundle\View\TwigView;
@@ -315,11 +316,15 @@ final class TwigViewIntegrationTest extends TestCase
                         $viewFactory = new ViewFactory();
                         $viewFactory->set('twig', new TwigView($this->testCase->twig));
 
+                        $routeGeneratorFactory = new RequestAwareRouteGeneratorFactory(
+                            $this->testCase->router,
+                            $this->testCase->requestStack
+                        );
+
                         return new PagerfantaRuntime(
                             'twig',
                             $viewFactory,
-                            $this->testCase->router,
-                            $this->testCase->requestStack
+                            $routeGeneratorFactory
                         );
 
                     default:

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,16 @@
         "pagerfanta/pagerfanta": "^1.1 || ^2.0",
         "symfony/config": "^3.4 || ^4.4 || ^5.0",
         "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0",
-        "symfony/http-kernel": "^3.4 || ^4.4 || ^5.0"
+        "symfony/http-foundation": "^3.4 || ^4.4 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.4 || ^5.0",
+        "symfony/property-access": "^3.4 || ^4.4 || ^5.0",
+        "symfony/routing": "^3.4 || ^4.4 || ^5.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.8",
         "friendsofphp/php-cs-fixer": "^2.16",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpunit/phpunit": "^8.5 || ^9.0",
-        "symfony/http-foundation": "^3.4 || ^4.4 || ^5.0",
-        "symfony/property-access": "^3.4 || ^4.4 || ^5.0",
-        "symfony/routing": "^3.4 || ^4.4 || ^5.0",
         "symfony/twig-bridge": "^3.4 || ^4.4 || ^5.0",
         "symfony/translation": "^3.4 || ^4.4 || ^5.0",
         "twig/twig": "^1.34 || ^2.4 || ^3.0"
@@ -28,9 +28,6 @@
         "white-october/pagerfanta-bundle": "*"
     },
     "suggest": {
-        "symfony/http-foundation": "To use the PagerfantaExtension for Twig",
-        "symfony/property-access": "To use the PagerfantaExtension for Twig",
-        "symfony/routing": "To use the PagerfantaExtension for Twig",
         "symfony/translation": "To use the Pagerfanta views with translation support",
         "twig/twig": "To integrate Pagerfanta with Twig through extensions"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "phpunit/phpunit": "^8.5 || ^9.0",
         "symfony/http-foundation": "^3.4 || ^4.4 || ^5.0",
         "symfony/property-access": "^3.4 || ^4.4 || ^5.0",
-        "symfony/options-resolver": "^3.4 || ^4.4 || ^5.0",
         "symfony/routing": "^3.4 || ^4.4 || ^5.0",
         "symfony/twig-bridge": "^3.4 || ^4.4 || ^5.0",
         "symfony/translation": "^3.4 || ^4.4 || ^5.0",
@@ -31,7 +30,6 @@
     "suggest": {
         "symfony/http-foundation": "To use the PagerfantaExtension for Twig",
         "symfony/property-access": "To use the PagerfantaExtension for Twig",
-        "symfony/options-resolver": "To use the request aware route resolver",
         "symfony/routing": "To use the PagerfantaExtension for Twig",
         "symfony/translation": "To use the Pagerfanta views with translation support",
         "twig/twig": "To integrate Pagerfanta with Twig through extensions"

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "phpunit/phpunit": "^8.5 || ^9.0",
         "symfony/http-foundation": "^3.4 || ^4.4 || ^5.0",
         "symfony/property-access": "^3.4 || ^4.4 || ^5.0",
+        "symfony/options-resolver": "^3.4 || ^4.4 || ^5.0",
         "symfony/routing": "^3.4 || ^4.4 || ^5.0",
         "symfony/twig-bridge": "^3.4 || ^4.4 || ^5.0",
         "symfony/translation": "^3.4 || ^4.4 || ^5.0",
@@ -30,6 +31,7 @@
     "suggest": {
         "symfony/http-foundation": "To use the PagerfantaExtension for Twig",
         "symfony/property-access": "To use the PagerfantaExtension for Twig",
+        "symfony/options-resolver": "To use the request aware route resolver",
         "symfony/routing": "To use the PagerfantaExtension for Twig",
         "symfony/translation": "To use the Pagerfanta views with translation support",
         "twig/twig": "To integrate Pagerfanta with Twig through extensions"


### PR DESCRIPTION
Right now, the Twig integration has the logic for building a route generator used in the Pagerfanta views to create the URLs for the items in the pagination list hardcoded into it.  This PR extracts that logic out into a couple of new interfaces with default implementations matching the existing behavior.

`BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorInterface` is the actual route generator service that will be used by a `Pagerfanta\View\ViewInterface` instance when rendering the list, since the argument is loosely typed as a callable in the Pagerfanta interface's doc block the `RouteGeneratorInterface` requires implementing classes to use the `__invoke()` method.  The default implementation is what was the Closure returned by the Twig runtime class' helper method, which uses the Symfony router to build routes.

`BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorFactoryInterface` is a factory service that can be used to create a `RouteGeneratorInterface` at runtime.  The default implementation is all of the logic that was in the Twig runtime class' helper method which was used to build the options array used by the generator, so this factory requires the Symfony `Request` object to work and returns an instance of `BabDev\PagerfantaBundle\RouteGenerator\RouterAwareRouteGenerator`.

The factory service is exposed to the container with a public service, `pagerfanta.route_generator_factory`, and this service is used by the Twig integration to allow everything to work properly.  This should be the primary extension point if a custom generator is needed in your application.