### PR TITLE
Fix symfony 5.1 deprecations

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.2, 7.3, 7.4]
-        symfony: [3.4.*, 4.4.*, 5.0.*]
+        symfony: [3.4.*, 4.4.*, 5.0.*, 5.1.*]
         composer-flags: ['--prefer-stable']
         next-symfony: [false]
         include:
@@ -18,10 +18,6 @@ jobs:
             symfony: 3.4.*
             composer-flags: '--prefer-stable --prefer-lowest'
             next-symfony: false
-          - php: 7.4
-            symfony: 5.1.*@rc
-            composer-flags: '--prefer-stable'
-            next-symfony: true
           - php: 7.4
             symfony: 5.2.*@dev
             composer-flags: '--prefer-stable'

--- a/DependencyInjection/BabDevPagerfantaExtension.php
+++ b/DependencyInjection/BabDevPagerfantaExtension.php
@@ -3,6 +3,7 @@
 namespace BabDev\PagerfantaBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -23,6 +24,11 @@ final class BabDevPagerfantaExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('pagerfanta.xml');
+        if (method_exists(Alias::class, 'getDeprecation')) {
+            $loader->load('deprecated_51.xml');
+        } else {
+            $loader->load('deprecated.xml');
+        }
 
         if (Configuration::EXCEPTION_STRATEGY_TO_HTTP_NOT_FOUND === $config['exceptions_strategy']['out_of_range_page']) {
             $container->getDefinition('pagerfanta.event_listener.convert_not_valid_max_per_page_to_not_found')

--- a/Resources/config/deprecated.xml
+++ b/Resources/config/deprecated.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Deprecated services -->
+
+        <!-- Pagerfanta Views -->
+        <service id="pagerfanta.view.default_translated" class="BabDev\PagerfantaBundle\View\DefaultTranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.default" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="default_translated" />
+            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "default.html.twig" template.</deprecated>
+        </service>
+
+        <service id="pagerfanta.view.semantic_ui_translated" class="BabDev\PagerfantaBundle\View\SemanticUiTranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.semantic_ui" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="semantic_ui_translated" />
+            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "semantic_ui.html.twig" template.</deprecated>
+        </service>
+
+        <service id="pagerfanta.view.twitter_bootstrap_translated" class="BabDev\PagerfantaBundle\View\TwitterBootstrapTranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.twitter_bootstrap" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="twitter_bootstrap_translated" />
+            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "twitter_bootstrap.html.twig" template.</deprecated>
+        </service>
+
+        <service id="pagerfanta.view.twitter_bootstrap3_translated" class="BabDev\PagerfantaBundle\View\TwitterBootstrap3TranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.twitter_bootstrap3" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="twitter_bootstrap3_translated" />
+            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "twitter_bootstrap3.html.twig" template.</deprecated>
+        </service>
+
+        <service id="pagerfanta.view.twitter_bootstrap4_translated" class="BabDev\PagerfantaBundle\View\TwitterBootstrap4TranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.twitter_bootstrap4" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="twitter_bootstrap4_translated" />
+            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "twitter_bootstrap4.html.twig" template.</deprecated>
+        </service>
+    </services>
+</container>

--- a/Resources/config/deprecated_51.xml
+++ b/Resources/config/deprecated_51.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Deprecated services -->
+        <!-- Updated deprecation element for Symfony 5.1+ -->
+
+        <!-- Pagerfanta Views -->
+        <service id="pagerfanta.view.default_translated" class="BabDev\PagerfantaBundle\View\DefaultTranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.default" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="default_translated" />
+            <deprecated package="babdev/pagerfanta-bundle" version="2.2">The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "default.html.twig" template.</deprecated>
+        </service>
+
+        <service id="pagerfanta.view.semantic_ui_translated" class="BabDev\PagerfantaBundle\View\SemanticUiTranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.semantic_ui" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="semantic_ui_translated" />
+            <deprecated package="babdev/pagerfanta-bundle" version="2.2">The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "semantic_ui.html.twig" template.</deprecated>
+        </service>
+
+        <service id="pagerfanta.view.twitter_bootstrap_translated" class="BabDev\PagerfantaBundle\View\TwitterBootstrapTranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.twitter_bootstrap" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="twitter_bootstrap_translated" />
+            <deprecated package="babdev/pagerfanta-bundle" version="2.2">The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "twitter_bootstrap.html.twig" template.</deprecated>
+        </service>
+
+        <service id="pagerfanta.view.twitter_bootstrap3_translated" class="BabDev\PagerfantaBundle\View\TwitterBootstrap3TranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.twitter_bootstrap3" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="twitter_bootstrap3_translated" />
+            <deprecated package="babdev/pagerfanta-bundle" version="2.2">The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "twitter_bootstrap3.html.twig" template.</deprecated>
+        </service>
+
+        <service id="pagerfanta.view.twitter_bootstrap4_translated" class="BabDev\PagerfantaBundle\View\TwitterBootstrap4TranslatedView" public="false">
+            <argument type="service" id="pagerfanta.view.twitter_bootstrap4" />
+            <argument type="service" id="translator" />
+            <tag name="pagerfanta.view" alias="twitter_bootstrap4_translated" />
+            <deprecated package="babdev/pagerfanta-bundle" version="2.2">The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "twitter_bootstrap4.html.twig" template.</deprecated>
+        </service>
+    </services>
+</container>

--- a/Resources/config/pagerfanta.xml
+++ b/Resources/config/pagerfanta.xml
@@ -39,22 +39,8 @@
             <tag name="pagerfanta.view" alias="default" />
         </service>
 
-        <service id="pagerfanta.view.default_translated" class="BabDev\PagerfantaBundle\View\DefaultTranslatedView" public="false">
-            <argument type="service" id="pagerfanta.view.default" />
-            <argument type="service" id="translator" />
-            <tag name="pagerfanta.view" alias="default_translated" />
-            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "default.html.twig" template.</deprecated>
-        </service>
-
         <service id="pagerfanta.view.semantic_ui" class="Pagerfanta\View\SemanticUiView" public="false">
             <tag name="pagerfanta.view" alias="semantic_ui" />
-        </service>
-
-        <service id="pagerfanta.view.semantic_ui_translated" class="BabDev\PagerfantaBundle\View\SemanticUiTranslatedView" public="false">
-            <argument type="service" id="pagerfanta.view.semantic_ui" />
-            <argument type="service" id="translator" />
-            <tag name="pagerfanta.view" alias="semantic_ui_translated" />
-            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "semantic_ui.html.twig" template.</deprecated>
         </service>
 
         <service id="pagerfanta.view.twig" class="BabDev\PagerfantaBundle\View\TwigView" public="false">
@@ -67,33 +53,12 @@
             <tag name="pagerfanta.view" alias="twitter_bootstrap" />
         </service>
 
-        <service id="pagerfanta.view.twitter_bootstrap_translated" class="BabDev\PagerfantaBundle\View\TwitterBootstrapTranslatedView" public="false">
-            <argument type="service" id="pagerfanta.view.twitter_bootstrap" />
-            <argument type="service" id="translator" />
-            <tag name="pagerfanta.view" alias="twitter_bootstrap_translated" />
-            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "twitter_bootstrap.html.twig" template.</deprecated>
-        </service>
-
         <service id="pagerfanta.view.twitter_bootstrap3" class="Pagerfanta\View\TwitterBootstrap3View" public="false">
             <tag name="pagerfanta.view" alias="twitter_bootstrap3" />
         </service>
 
-        <service id="pagerfanta.view.twitter_bootstrap3_translated" class="BabDev\PagerfantaBundle\View\TwitterBootstrap3TranslatedView" public="false">
-            <argument type="service" id="pagerfanta.view.twitter_bootstrap3" />
-            <argument type="service" id="translator" />
-            <tag name="pagerfanta.view" alias="twitter_bootstrap3_translated" />
-            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "twitter_bootstrap3.html.twig" template.</deprecated>
-        </service>
-
         <service id="pagerfanta.view.twitter_bootstrap4" class="Pagerfanta\View\TwitterBootstrap4View" public="false">
             <tag name="pagerfanta.view" alias="twitter_bootstrap4" />
-        </service>
-
-        <service id="pagerfanta.view.twitter_bootstrap4_translated" class="BabDev\PagerfantaBundle\View\TwitterBootstrap4TranslatedView" public="false">
-            <argument type="service" id="pagerfanta.view.twitter_bootstrap4" />
-            <argument type="service" id="translator" />
-            <tag name="pagerfanta.view" alias="twitter_bootstrap4_translated" />
-            <deprecated>The "%service_id%" service is deprecated and will be removed in BabDevPagerfantaBundle 3.0. Use the "pagerfanta.view.twig" service instead with the "twitter_bootstrap4.html.twig" template.</deprecated>
         </service>
 
         <!-- View Factory -->


### PR DESCRIPTION
In symfony 5.1 the package and version attribute should be set on the deprecated xml element.