### PR TITLE
Use Twig Features From Core Package

### DIFF
--- a/BabDevPagerfantaBundle.php
+++ b/BabDevPagerfantaBundle.php
@@ -3,6 +3,7 @@
 namespace BabDev\PagerfantaBundle;
 
 use BabDev\PagerfantaBundle\DependencyInjection\BabDevPagerfantaExtension;
+use BabDev\PagerfantaBundle\DependencyInjection\CompilerPass\AddPackageTemplatePathToTwigPass;
 use BabDev\PagerfantaBundle\DependencyInjection\CompilerPass\AddPagerfantasPass;
 use BabDev\PagerfantaBundle\DependencyInjection\CompilerPass\MaybeRemoveTranslatedViewsPass;
 use BabDev\PagerfantaBundle\DependencyInjection\CompilerPass\MaybeRemoveTwigServicesPass;
@@ -21,6 +22,7 @@ final class BabDevPagerfantaBundle extends Bundle
         $container->addCompilerPass(new MaybeRemoveTranslatedViewsPass(true));
         $container->addCompilerPass(new AddPagerfantasPass());
         $container->addCompilerPass(new MaybeRemoveTwigServicesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new AddPackageTemplatePathToTwigPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 
     public function getContainerExtension()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 2.5.0 (2020-??-??)
 
 - Add the `referenceType` option to the `RouterAwareRouteGenerator` to allow specifying the `$referenceType` parameter when calling `Symfony\Component\Routing\Generator\UrlGeneratorInterface::generate()`
-- Deprecate the `RouteGeneratorFactoryInterface` and `RouteGeneratorInterface` in favor of the interfaces from the base Pagerfanta package
+- Deprecate the `RouteGeneratorFactoryInterface` and `RouteGeneratorInterface` in favor of the interfaces from the `pagerfanta/core` package
+- Deprecate the Twig extension, runtime extension, and Pagerfanta view in favor of the classes from the `pagerfanta/twig` package
 
 ## 2.4.2 (2020-06-09)
 

--- a/DependencyInjection/BabDevPagerfantaExtension.php
+++ b/DependencyInjection/BabDevPagerfantaExtension.php
@@ -40,6 +40,12 @@ final class BabDevPagerfantaExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('pagerfanta.xml');
 
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (isset($bundles['TwigBundle'])) {
+            $loader->load('twig.xml');
+        }
+
         if (Configuration::EXCEPTION_STRATEGY_TO_HTTP_NOT_FOUND === $config['exceptions_strategy']['out_of_range_page']) {
             $container->getDefinition('pagerfanta.event_listener.convert_not_valid_max_per_page_to_not_found')
                 ->addTag(

--- a/DependencyInjection/CompilerPass/AddPackageTemplatePathToTwigPass.php
+++ b/DependencyInjection/CompilerPass/AddPackageTemplatePathToTwigPass.php
@@ -2,7 +2,7 @@
 
 namespace BabDev\PagerfantaBundle\DependencyInjection\CompilerPass;
 
-use Pagerfanta\Pagerfanta;
+use Pagerfanta\Twig\Extension\PagerfantaExtension;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -11,8 +11,8 @@ final class AddPackageTemplatePathToTwigPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         if ($container->hasDefinition('twig.loader.native_filesystem')) {
-            $refl = new \ReflectionClass(Pagerfanta::class);
-            $path = \dirname($refl->getFileName()).'/../templates';
+            $refl = new \ReflectionClass(PagerfantaExtension::class);
+            $path = \dirname($refl->getFileName(), 2).'/templates';
 
             $container->getDefinition('twig.loader.native_filesystem')
                 ->addMethodCall('addPath', [$path, 'Pagerfanta']);

--- a/DependencyInjection/CompilerPass/AddPackageTemplatePathToTwigPass.php
+++ b/DependencyInjection/CompilerPass/AddPackageTemplatePathToTwigPass.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\DependencyInjection\CompilerPass;
+
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AddPackageTemplatePathToTwigPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('twig.loader.native_filesystem')) {
+            $refl = new \ReflectionClass(Pagerfanta::class);
+            $path = \dirname($refl->getFileName()).'/../templates';
+
+            $container->getDefinition('twig.loader.native_filesystem')
+                ->addMethodCall('addPath', [$path, 'Pagerfanta']);
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('default_twig_template')
                     ->info('The default Twig template to use when using the Twig Pagerfanta view')
-                    ->defaultValue(TwigView::DEFAULT_TEMPLATE)
+                    ->defaultValue('@BabDevPagerfanta/default.html.twig')
                 ->end()
                 ->arrayNode('exceptions_strategy')
                     ->addDefaultsIfNotSet()

--- a/Resources/config/pagerfanta.xml
+++ b/Resources/config/pagerfanta.xml
@@ -22,19 +22,6 @@
         <service id="BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorFactoryInterface" alias="pagerfanta.route_generator_factory" />
         <service id="Pagerfanta\RouteGenerator\RouteGeneratorFactoryInterface" alias="pagerfanta.route_generator_factory" />
 
-        <!-- Twig Extension -->
-        <service id="pagerfanta.twig_extension" class="BabDev\PagerfantaBundle\Twig\PagerfantaExtension" public="false">
-            <tag name="twig.extension" />
-        </service>
-
-        <!-- Twig Runtime -->
-        <service id="pagerfanta.twig_runtime" class="BabDev\PagerfantaBundle\Twig\PagerfantaRuntime" public="false">
-            <argument>%babdev_pagerfanta.default_view%</argument>
-            <argument type="service" id="pagerfanta.view_factory" />
-            <argument type="service" id="pagerfanta.route_generator_factory" />
-            <tag name="twig.runtime" />
-        </service>
-
         <!-- Pagerfanta Views -->
         <service id="pagerfanta.view.default" class="Pagerfanta\View\DefaultView" public="false">
             <tag name="pagerfanta.view" alias="default" />
@@ -56,12 +43,6 @@
             <argument type="service" id="translator" />
             <tag name="pagerfanta.view" alias="semantic_ui_translated" />
             <!-- deprecated service, deprecation is set in the container extension -->
-        </service>
-
-        <service id="pagerfanta.view.twig" class="BabDev\PagerfantaBundle\View\TwigView" public="false">
-            <argument type="service" id="twig" />
-            <argument>%babdev_pagerfanta.default_twig_template%</argument>
-            <tag name="pagerfanta.view" alias="twig" />
         </service>
 
         <service id="pagerfanta.view.twitter_bootstrap" class="Pagerfanta\View\TwitterBootstrapView" public="false">

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Twig Extension -->
+        <service id="pagerfanta.twig_extension" class="Pagerfanta\Twig\PagerfantaExtension" public="false">
+            <tag name="twig.extension" />
+        </service>
+
+        <!-- Twig Runtime -->
+        <service id="pagerfanta.twig_runtime" class="Pagerfanta\Twig\PagerfantaRuntime" public="false">
+            <argument>%babdev_pagerfanta.default_view%</argument>
+            <argument type="service" id="pagerfanta.view_factory" />
+            <argument type="service" id="pagerfanta.route_generator_factory" />
+            <tag name="twig.runtime" />
+        </service>
+
+        <!-- Pagerfanta View -->
+        <service id="pagerfanta.view.twig" class="Pagerfanta\View\TwigView" public="false">
+            <argument type="service" id="twig" />
+            <argument>%babdev_pagerfanta.default_twig_template%</argument>
+            <tag name="pagerfanta.view" alias="twig" />
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -6,12 +6,12 @@
 
     <services>
         <!-- Twig Extension -->
-        <service id="pagerfanta.twig_extension" class="Pagerfanta\Twig\PagerfantaExtension" public="false">
+        <service id="pagerfanta.twig_extension" class="Pagerfanta\Twig\Extension\PagerfantaExtension" public="false">
             <tag name="twig.extension" />
         </service>
 
         <!-- Twig Runtime -->
-        <service id="pagerfanta.twig_runtime" class="Pagerfanta\Twig\PagerfantaRuntime" public="false">
+        <service id="pagerfanta.twig_runtime" class="Pagerfanta\Twig\Extension\PagerfantaRuntime" public="false">
             <argument>%babdev_pagerfanta.default_view%</argument>
             <argument type="service" id="pagerfanta.view_factory" />
             <argument type="service" id="pagerfanta.route_generator_factory" />
@@ -19,7 +19,7 @@
         </service>
 
         <!-- Pagerfanta View -->
-        <service id="pagerfanta.view.twig" class="Pagerfanta\View\TwigView" public="false">
+        <service id="pagerfanta.view.twig" class="Pagerfanta\Twig\View\TwigView" public="false">
             <argument type="service" id="twig" />
             <argument>%babdev_pagerfanta.default_twig_template%</argument>
             <tag name="pagerfanta.view" alias="twig" />

--- a/Resources/views/default.html.twig
+++ b/Resources/views/default.html.twig
@@ -1,90 +1,4 @@
-{%- block pager_widget -%}
-    <nav>
-        {{- block('pager') -}}
-    </nav>
-{%- endblock pager_widget -%}
-
-{%- block pager -%}
-    {# Previous Page Link #}
-    {%- if pagerfanta.hasPreviousPage() -%}
-        {%- set path = route_generator.route(pagerfanta.getPreviousPage()) -%}
-        {{- block('previous_page_link') -}}
-    {%- else -%}
-        {{- block('previous_page_link_disabled') -}}
-    {%- endif -%}
-
-    {# First Page Link #}
-    {%- if start_page > 1 -%}
-        {%- set page = 1 -%}
-        {%- set path = route_generator.route(page) -%}
-        {{- block('page_link') -}}
-    {%- endif -%}
-
-    {# Second Page Link, displays if we are on page 3 #}
-    {%- if start_page == 3 -%}
-        {%- set page = 2 -%}
-        {%- set path = route_generator.route(page) -%}
-        {{- block('page_link') -}}
-    {%- endif -%}
-
-    {# Separator, creates a "..." separator to limit the number of items if we are starting beyond page 3 #}
-    {%- if start_page > 3 -%}
-        {{- block('ellipsis') -}}
-    {%- endif -%}
-
-    {# Page Links #}
-    {%- for page in range(start_page, end_page) -%}
-        {%- set path = route_generator.route(page) -%}
-        {%- if page == current_page -%}
-            {{- block('current_page_link') -}}
-        {%- else -%}
-            {{- block('page_link') -}}
-        {%- endif -%}
-    {%- endfor -%}
-
-    {# Separator, creates a "..." separator to limit the number of items if we are over 3 pages away from the last page #}
-    {%- if end_page < (nb_pages - 2) -%}
-        {{- block('ellipsis') -}}
-    {%- endif -%}
-
-    {# Second to Last Page Link, displays if we are on the third from last page #}
-    {%- if end_page == (nb_pages - 2) -%}
-        {%- set page = (nb_pages - 1) -%}
-        {%- set path = route_generator.route(page) -%}
-        {{- block('page_link') -}}
-    {%- endif -%}
-
-    {# Last Page Link #}
-    {%- if nb_pages > end_page -%}
-        {%- set page = nb_pages -%}
-        {%- set path = route_generator.route(page) -%}
-        {{- block('page_link') -}}
-    {%- endif -%}
-
-    {# Next Page Link #}
-    {%- if pagerfanta.hasNextPage() -%}
-        {%- set path = route_generator.route(pagerfanta.getNextPage()) -%}
-        {{- block('next_page_link') -}}
-    {%- else -%}
-        {{- block('next_page_link_disabled') -}}
-    {%- endif -%}
-{%- endblock pager -%}
-
-{%- block page_link -%}
-    <a href="{{- path -}}">{{- page -}}</a>
-{%- endblock page_link -%}
-
-{%- block current_page_link -%}
-    <span class="current" aria-current="page">{{- page -}}</span>
-{%- endblock current_page_link -%}
-
-{%- block previous_page_link -%}
-    <a href="{{- path -}}" rel="prev">{{- block('previous_page_message') -}}</a>
-{%- endblock previous_page_link -%}
-
-{%- block previous_page_link_disabled -%}
-    <span class="disabled">{{- block('previous_page_message') -}}</span>
-{%- endblock previous_page_link_disabled -%}
+{%- extends '@Pagerfanta/default.html.twig' -%}
 
 {%- block previous_page_message -%}
     {%- if options['prev_message'] is defined -%}
@@ -94,14 +8,6 @@
     {%- endif -%}
 {%- endblock previous_page_message -%}
 
-{%- block next_page_link -%}
-    <a href="{{- path -}}" rel="next">{{- block('next_page_message') -}}</a>
-{%- endblock next_page_link -%}
-
-{%- block next_page_link_disabled -%}
-    <span class="disabled">{{- block('next_page_message') -}}</span>
-{%- endblock next_page_link_disabled -%}
-
 {%- block next_page_message -%}
     {%- if options['next_message'] is defined -%}
         {{- options['next_message'] -}}
@@ -109,7 +15,3 @@
         {{- 'next'|trans([], 'pagerfanta') -}}
     {%- endif -%}
 {%- endblock next_page_message -%}
-
-{%- block ellipsis -%}
-    <span class="dots">...</span>
-{%- endblock ellipsis -%}

--- a/RouteGenerator/RouteGeneratorDecorator.php
+++ b/RouteGenerator/RouteGeneratorDecorator.php
@@ -2,8 +2,14 @@
 
 namespace BabDev\PagerfantaBundle\RouteGenerator;
 
+use Pagerfanta\RouteGenerator\RouteGeneratorDecorator as PagerfantaRouteGeneratorDecorator;
 use Pagerfanta\RouteGenerator\RouteGeneratorInterface;
 
+trigger_deprecation('babdev/pagerfanta-bundle', '2.5', 'The "%s" class is deprecated and will be removed in 3.0. Use the "%s" class instead.', RouteGeneratorDecorator::class, PagerfantaRouteGeneratorDecorator::class);
+
+/**
+ * @deprecated to be removed in BabDevPagerfantaBundle 3.0. Use `Pagerfanta\RouteGenerator\RouteGeneratorDecorator` instead.
+ */
 final class RouteGeneratorDecorator implements RouteGeneratorInterface
 {
     /**

--- a/Tests/DependencyInjection/BabDevPagerfantaExtensionTest.php
+++ b/Tests/DependencyInjection/BabDevPagerfantaExtensionTest.php
@@ -7,13 +7,19 @@ use BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorFactoryInterface;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Pagerfanta\View\ViewFactory;
 use Pagerfanta\View\ViewFactoryInterface;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 final class BabDevPagerfantaExtensionTest extends AbstractExtensionTestCase
 {
-    public function testContainerIsLoadedWithDefaultConfiguration(): void
+    public function testContainerIsLoadedWithDefaultConfigurationWhenTwigBundleIsNotInstalled(): void
     {
+        $this->container->setParameter(
+            'kernel.bundles',
+            []
+        );
+
         $this->load();
 
         $this->assertContainerBuilderHasParameter('babdev_pagerfanta.default_view');
@@ -62,10 +68,94 @@ final class BabDevPagerfantaExtensionTest extends AbstractExtensionTestCase
                 ]
             );
         }
+
+        $twigServices = [
+            'pagerfanta.twig_extension',
+            'pagerfanta.twig_runtime',
+            'pagerfanta.view.twig',
+        ];
+
+        foreach ($twigServices as $twigService) {
+            $this->assertContainerBuilderNotHasService($twigService);
+        }
+    }
+
+    public function testContainerIsLoadedWithDefaultConfigurationWhenTwigBundleIsInstalled(): void
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'TwigBundle' => TwigBundle::class,
+            ]
+        );
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('babdev_pagerfanta.default_view');
+        $this->assertContainerBuilderHasParameter('babdev_pagerfanta.default_twig_template');
+
+        $this->assertContainerBuilderHasAlias(ViewFactory::class, 'pagerfanta.view_factory');
+        $this->assertContainerBuilderHasAlias(ViewFactoryInterface::class, 'pagerfanta.view_factory');
+
+        $deprecatedViews = [
+            'pagerfanta.view.default_translated',
+            'pagerfanta.view.semantic_ui_translated',
+            'pagerfanta.view.twitter_bootstrap_translated',
+            'pagerfanta.view.twitter_bootstrap3_translated',
+            'pagerfanta.view.twitter_bootstrap4_translated',
+        ];
+
+        foreach ($deprecatedViews as $deprecatedView) {
+            $this->assertContainerBuilderHasService($deprecatedView);
+            $this->assertTrue($this->container->getDefinition($deprecatedView)->isDeprecated());
+        }
+
+        if (method_exists(Alias::class, 'setDeprecated')) {
+            $deprecatedAliases = [
+                RouteGeneratorFactoryInterface::class,
+            ];
+
+            foreach ($deprecatedAliases as $deprecatedAlias) {
+                $this->assertContainerBuilderHasAlias($deprecatedAlias);
+                $this->assertTrue($this->container->getAlias($deprecatedAlias)->isDeprecated());
+            }
+        }
+
+        $listeners = [
+            'pagerfanta.event_listener.convert_not_valid_max_per_page_to_not_found',
+            'pagerfanta.event_listener.convert_not_valid_current_page_to_not_found',
+        ];
+
+        foreach ($listeners as $listener) {
+            $this->assertContainerBuilderHasServiceDefinitionWithTag(
+                $listener,
+                'kernel.event_listener',
+                [
+                    'event' => KernelEvents::EXCEPTION,
+                    'method' => 'onKernelException',
+                    'priority' => 512,
+                ]
+            );
+        }
+
+        $twigServices = [
+            'pagerfanta.twig_extension',
+            'pagerfanta.twig_runtime',
+            'pagerfanta.view.twig',
+        ];
+
+        foreach ($twigServices as $twigService) {
+            $this->assertContainerBuilderHasService($twigService);
+        }
     }
 
     public function testContainerIsLoadedWhenBundleIsConfiguredWithCustomExceptionStrategies(): void
     {
+        $this->container->setParameter(
+            'kernel.bundles',
+            []
+        );
+
         $bundleConfig = [
             'exceptions_strategy' => [
                 'out_of_range_page' => 'custom_handler',

--- a/Tests/DependencyInjection/CompilerPass/AddPackageTemplatePathToTwigPassTest.php
+++ b/Tests/DependencyInjection/CompilerPass/AddPackageTemplatePathToTwigPassTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\Tests\DependencyInjection\CompilerPass;
+
+use BabDev\PagerfantaBundle\DependencyInjection\CompilerPass\AddPackageTemplatePathToTwigPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Twig\Loader\FilesystemLoader;
+
+final class AddPackageTemplatePathToTwigPassTest extends AbstractCompilerPassTestCase
+{
+    public function testThePackateTemplatePathIsAddedToTheTwigFilesystemLoader(): void
+    {
+        $this->registerService('twig.loader.native_filesystem', FilesystemLoader::class);
+
+        $this->compile();
+
+        $refl = new \ReflectionClass(Pagerfanta::class);
+        $path = \dirname($refl->getFileName()).'/../templates';
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'twig.loader.native_filesystem',
+            'addPath',
+            [$path, 'Pagerfanta']
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AddPackageTemplatePathToTwigPass());
+    }
+}

--- a/Tests/DependencyInjection/CompilerPass/AddPackageTemplatePathToTwigPassTest.php
+++ b/Tests/DependencyInjection/CompilerPass/AddPackageTemplatePathToTwigPassTest.php
@@ -4,7 +4,7 @@ namespace BabDev\PagerfantaBundle\Tests\DependencyInjection\CompilerPass;
 
 use BabDev\PagerfantaBundle\DependencyInjection\CompilerPass\AddPackageTemplatePathToTwigPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
-use Pagerfanta\Pagerfanta;
+use Pagerfanta\Twig\Extension\PagerfantaExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Twig\Loader\FilesystemLoader;
 
@@ -16,8 +16,8 @@ final class AddPackageTemplatePathToTwigPassTest extends AbstractCompilerPassTes
 
         $this->compile();
 
-        $refl = new \ReflectionClass(Pagerfanta::class);
-        $path = \dirname($refl->getFileName()).'/../templates';
+        $refl = new \ReflectionClass(PagerfantaExtension::class);
+        $path = \dirname($refl->getFileName(), 2).'/templates';
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'twig.loader.native_filesystem',

--- a/Tests/View/TwigViewIntegrationTest.php
+++ b/Tests/View/TwigViewIntegrationTest.php
@@ -54,8 +54,12 @@ final class TwigViewIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
+        $refl = new \ReflectionClass(Pagerfanta::class);
+        $path = \dirname($refl->getFileName()).'/../templates';
+
         $filesystemLoader = new FilesystemLoader();
         $filesystemLoader->addPath(__DIR__.'/../../Resources/views', 'BabDevPagerfanta');
+        $filesystemLoader->addPath($path, 'Pagerfanta');
 
         $this->twig = new Environment(new ChainLoader([new ArrayLoader(['integration.html.twig' => '{{ pagerfanta(pager, options) }}']), $filesystemLoader]));
         $this->twig->addExtension(new PagerfantaExtension());

--- a/Tests/View/TwigViewIntegrationTest.php
+++ b/Tests/View/TwigViewIntegrationTest.php
@@ -8,6 +8,7 @@ use BabDev\PagerfantaBundle\Twig\PagerfantaRuntime;
 use BabDev\PagerfantaBundle\View\TwigView;
 use Pagerfanta\Adapter\FixedAdapter;
 use Pagerfanta\Pagerfanta;
+use Pagerfanta\Twig\Extension\PagerfantaExtension as CorePagerfantaExtension;
 use Pagerfanta\View\ViewFactory;
 use Pagerfanta\View\ViewFactoryInterface;
 use PHPUnit\Framework\TestCase;
@@ -54,8 +55,8 @@ final class TwigViewIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
-        $refl = new \ReflectionClass(Pagerfanta::class);
-        $path = \dirname($refl->getFileName()).'/../templates';
+        $refl = new \ReflectionClass(CorePagerfantaExtension::class);
+        $path = \dirname($refl->getFileName(), 2).'/templates';
 
         $filesystemLoader = new FilesystemLoader();
         $filesystemLoader->addPath(__DIR__.'/../../Resources/views', 'BabDevPagerfanta');

--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -2,16 +2,22 @@
 
 namespace BabDev\PagerfantaBundle\Twig;
 
+use Pagerfanta\Twig\PagerfantaExtension as PagerfantaPagerfantaExtension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+trigger_deprecation('babdev/pagerfanta-bundle', '2.5', 'The "%s" class is deprecated and will be removed in 3.0. Use the "%s" class instead.', PagerfantaExtension::class, PagerfantaPagerfantaExtension::class);
+
+/**
+ * @deprecated to be removed in BabDevPagerfantaBundle 3.0. Use `Pagerfanta\Twig\PagerfantaExtension` instead.
+ */
 final class PagerfantaExtension extends AbstractExtension
 {
     public function getFunctions()
     {
         return [
-            new TwigFunction('pagerfanta', [PagerfantaRuntime::class, 'renderPagerfanta'], ['is_safe' => ['html']]),
-            new TwigFunction('pagerfanta_page_url', [PagerfantaRuntime::class, 'getPageUrl']),
+            new TwigFunction('pagerfanta', [PagerfantaRuntime::class, 'renderPagerfanta'], ['is_safe' => ['html'], 'deprecated' => true]),
+            new TwigFunction('pagerfanta_page_url', [PagerfantaRuntime::class, 'getPageUrl'], ['deprecated' => true]),
         ];
     }
 }

--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -2,14 +2,14 @@
 
 namespace BabDev\PagerfantaBundle\Twig;
 
-use Pagerfanta\Twig\PagerfantaExtension as PagerfantaPagerfantaExtension;
+use Pagerfanta\Twig\Extension\PagerfantaExtension as PagerfantaPagerfantaExtension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 trigger_deprecation('babdev/pagerfanta-bundle', '2.5', 'The "%s" class is deprecated and will be removed in 3.0. Use the "%s" class instead.', PagerfantaExtension::class, PagerfantaPagerfantaExtension::class);
 
 /**
- * @deprecated to be removed in BabDevPagerfantaBundle 3.0. Use `Pagerfanta\Twig\PagerfantaExtension` instead.
+ * @deprecated to be removed in BabDevPagerfantaBundle 3.0. Use `Pagerfanta\Twig\Extension\PagerfantaExtension` instead.
  */
 final class PagerfantaExtension extends AbstractExtension
 {

--- a/Twig/PagerfantaRuntime.php
+++ b/Twig/PagerfantaRuntime.php
@@ -7,15 +7,16 @@ use Pagerfanta\Pagerfanta;
 use Pagerfanta\PagerfantaInterface;
 use Pagerfanta\RouteGenerator\RouteGeneratorFactoryInterface;
 use Pagerfanta\RouteGenerator\RouteGeneratorInterface;
-use Pagerfanta\Twig\PagerfantaRuntime as PagerfantaPagerfantaRuntime;
+use Pagerfanta\Twig\Extension\PagerfantaRuntime as PagerfantaPagerfantaRuntime;
 use Pagerfanta\View\ViewFactoryInterface;
+use Twig\Extension\RuntimeExtensionInterface;
 
 trigger_deprecation('babdev/pagerfanta-bundle', '2.5', 'The "%s" class is deprecated and will be removed in 3.0. Use the "%s" class instead.', PagerfantaRuntime::class, PagerfantaPagerfantaRuntime::class);
 
 /**
- * @deprecated to be removed in BabDevPagerfantaBundle 3.0. Use `Pagerfanta\Twig\PagerfantaRuntime` instead.
+ * @deprecated to be removed in BabDevPagerfantaBundle 3.0. Use `Pagerfanta\Twig\Extension\PagerfantaRuntime` instead.
  */
-final class PagerfantaRuntime
+final class PagerfantaRuntime implements RuntimeExtensionInterface
 {
     /**
      * @var string

--- a/Twig/PagerfantaRuntime.php
+++ b/Twig/PagerfantaRuntime.php
@@ -7,8 +7,14 @@ use Pagerfanta\Pagerfanta;
 use Pagerfanta\PagerfantaInterface;
 use Pagerfanta\RouteGenerator\RouteGeneratorFactoryInterface;
 use Pagerfanta\RouteGenerator\RouteGeneratorInterface;
+use Pagerfanta\Twig\PagerfantaRuntime as PagerfantaPagerfantaRuntime;
 use Pagerfanta\View\ViewFactoryInterface;
 
+trigger_deprecation('babdev/pagerfanta-bundle', '2.5', 'The "%s" class is deprecated and will be removed in 3.0. Use the "%s" class instead.', PagerfantaRuntime::class, PagerfantaPagerfantaRuntime::class);
+
+/**
+ * @deprecated to be removed in BabDevPagerfantaBundle 3.0. Use `Pagerfanta\Twig\PagerfantaRuntime` instead.
+ */
 final class PagerfantaRuntime
 {
     /**

--- a/View/TwigView.php
+++ b/View/TwigView.php
@@ -5,9 +5,15 @@ namespace BabDev\PagerfantaBundle\View;
 use BabDev\PagerfantaBundle\RouteGenerator\RouteGeneratorDecorator;
 use Pagerfanta\Exception\InvalidArgumentException;
 use Pagerfanta\PagerfantaInterface;
+use Pagerfanta\View\TwigView as PagerfantaTwigView;
 use Pagerfanta\View\View;
 use Twig\Environment;
 
+trigger_deprecation('babdev/pagerfanta-bundle', '2.5', 'The "%s" class is deprecated and will be removed in 3.0. Use the "%s" class instead.', TwigView::class, PagerfantaTwigView::class);
+
+/**
+ * @deprecated to be removed in BabDevPagerfantaBundle 3.0. Use `Pagerfanta\View\TwigView` instead.
+ */
 final class TwigView extends View
 {
     public const DEFAULT_TEMPLATE = '@BabDevPagerfanta/default.html.twig';

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "pagerfanta/pagerfanta": "2.x-dev",
+        "pagerfanta/pagerfanta": "dev-feature/twig",
         "symfony/config": "^3.4 || ^4.4 || ^5.0",
         "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0",
         "symfony/deprecation-contracts": "^2.1",
@@ -21,6 +21,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "symfony/twig-bridge": "^3.4 || ^4.4 || ^5.0",
+        "symfony/twig-bundle": "^3.4 || ^4.4 || ^5.0",
         "symfony/translation": "^3.4 || ^4.4 || ^5.0",
         "twig/twig": "^1.34 || ^2.4 || ^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "pagerfanta/pagerfanta": "dev-feature/twig",
+        "pagerfanta/pagerfanta": "^2.4",
         "symfony/config": "^3.4 || ^4.4 || ^5.0",
         "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0",
         "symfony/deprecation-contracts": "^2.1",
@@ -23,10 +23,10 @@
         "symfony/twig-bridge": "^3.4 || ^4.4 || ^5.0",
         "symfony/twig-bundle": "^3.4 || ^4.4 || ^5.0",
         "symfony/translation": "^3.4 || ^4.4 || ^5.0",
-        "twig/twig": "^1.34 || ^2.4 || ^3.0"
+        "twig/twig": "^1.35 || ^2.5 || ^3.0"
     },
     "conflict": {
-        "twig/twig": "<1.34 || >=2.0,<2.4",
+        "twig/twig": "<1.35 || >=2.0,<2.5",
         "white-october/pagerfanta-bundle": "*"
     },
     "suggest": {


### PR DESCRIPTION
Depends on https://github.com/BabDev/Pagerfanta/pull/12

This adjusts the bundle to use the Twig classes from the parent package while deprecating those provided by the bundle.  The end result should be no new runtime deprecations by default as the service definitions are all changes to the parent package classes so it should be a pretty seamless transition unless someone is direct instantiating the bundle classes and not using the provided services.

The templates are a bit weird right now.  To keep supporting the translated message, the framework templates have to stay as is and act as duplications of those from the base package, it'd be nice to fully eliminate the templates from the bundle and just use those from the core package but I don't have a good idea on that yet.