### PR TITLE
Serializer Support

### DIFF
--- a/DependencyInjection/BabDevPagerfantaExtension.php
+++ b/DependencyInjection/BabDevPagerfantaExtension.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class BabDevPagerfantaExtension extends Extension implements PrependExtensionInterface
 {
@@ -41,6 +42,10 @@ final class BabDevPagerfantaExtension extends Extension implements PrependExtens
 
         if (isset($bundles['JMSSerializerBundle'])) {
             $loader->load('jms_serializer.xml');
+        }
+
+        if (interface_exists(NormalizerInterface::class)) {
+            $loader->load('serializer.xml');
         }
 
         if (Configuration::EXCEPTION_STRATEGY_TO_HTTP_NOT_FOUND === $config['exceptions_strategy']['out_of_range_page']) {

--- a/DependencyInjection/BabDevPagerfantaExtension.php
+++ b/DependencyInjection/BabDevPagerfantaExtension.php
@@ -39,6 +39,10 @@ final class BabDevPagerfantaExtension extends Extension implements PrependExtens
             $loader->load('twig.xml');
         }
 
+        if (isset($bundles['JMSSerializerBundle'])) {
+            $loader->load('jms_serializer.xml');
+        }
+
         if (Configuration::EXCEPTION_STRATEGY_TO_HTTP_NOT_FOUND === $config['exceptions_strategy']['out_of_range_page']) {
             $container->getDefinition('pagerfanta.event_listener.convert_not_valid_max_per_page_to_not_found')
                 ->addTag(

--- a/Resources/config/jms_serializer.xml
+++ b/Resources/config/jms_serializer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- JMS Serializer Handler -->
+        <service id="pagerfanta.serializer.handler" class="BabDev\PagerfantaBundle\Serializer\Handler\PagerfantaHandler" public="false">
+            <tag name="jms_serializer.subscribing_handler" />
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Symfony Serializer Normalizer -->
+        <service id="pagerfanta.serializer.normalizer" class="BabDev\PagerfantaBundle\Serializer\Normalizer\PagerfantaNormalizer" public="false">
+            <tag name="serializer.normalizer" />
+        </service>
+    </services>
+
+</container>

--- a/Serializer/Handler/PagerfantaHandler.php
+++ b/Serializer/Handler/PagerfantaHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\Serializer\Handler;
+
+use JMS\Serializer\GraphNavigatorInterface;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
+use Pagerfanta\Pagerfanta;
+
+final class PagerfantaHandler implements SubscribingHandlerInterface
+{
+    public static function getSubscribingMethods()
+    {
+        return [
+            [
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
+                'format' => 'json',
+                'type' => Pagerfanta::class,
+                'method' => 'serializeToJson',
+            ],
+        ];
+    }
+
+    /**
+     * @return array|\ArrayObject
+     */
+    public function serializeToJson(SerializationVisitorInterface $visitor, Pagerfanta $pagerfanta, array $type, SerializationContext $context)
+    {
+        return $visitor->visitArray(
+            [
+                'items' => $pagerfanta->getCurrentPageResults(),
+                'pagination' => [
+                    'current_page' => $pagerfanta->getCurrentPage(),
+                    'has_previous_page' => $pagerfanta->hasPreviousPage(),
+                    'has_next_page' => $pagerfanta->hasNextPage(),
+                    'per_page' => $pagerfanta->getMaxPerPage(),
+                    'total_items' => $pagerfanta->getNbResults(),
+                    'total_pages' => $pagerfanta->getNbPages(),
+                ],
+            ],
+            $type
+        );
+    }
+}

--- a/Serializer/Normalizer/PagerfantaNormalizer.php
+++ b/Serializer/Normalizer/PagerfantaNormalizer.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\Serializer\Normalizer;
+
+use Pagerfanta\PagerfantaInterface;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class PagerfantaNormalizer implements NormalizerInterface
+{
+    /**
+     * @param mixed $object Object to normalize
+     *
+     * @return array
+     *
+     * @throws InvalidArgumentException when the object given is not a supported type for the normalizer
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        if (!$object instanceof PagerfantaInterface) {
+            throw new InvalidArgumentException(sprintf('The object must be an instance of "%s".', PagerfantaInterface::class));
+        }
+
+        return [
+            'items' => $object->getCurrentPageResults(),
+            'pagination' => [
+                'current_page' => $object->getCurrentPage(),
+                'has_previous_page' => $object->hasPreviousPage(),
+                'has_next_page' => $object->hasNextPage(),
+                'per_page' => $object->getMaxPerPage(),
+                'total_items' => $object->getNbResults(),
+                'total_pages' => $object->getNbPages(),
+            ],
+        ];
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data instanceof PagerfantaInterface;
+    }
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return __CLASS__ === static::class;
+    }
+}

--- a/Tests/DependencyInjection/BabDevPagerfantaExtensionTest.php
+++ b/Tests/DependencyInjection/BabDevPagerfantaExtensionTest.php
@@ -72,6 +72,8 @@ final class BabDevPagerfantaExtensionTest extends AbstractExtensionTestCase
         foreach ($twigServices as $twigService) {
             $this->assertContainerBuilderNotHasService($twigService);
         }
+
+        $this->assertContainerBuilderHasService('pagerfanta.serializer.normalizer');
     }
 
     public function testContainerIsLoadedWithDefaultConfigurationWhenTwigBundleIsInstalled(): void
@@ -159,6 +161,8 @@ final class BabDevPagerfantaExtensionTest extends AbstractExtensionTestCase
         $path = \dirname($refl->getFileName(), 2).'/templates/';
 
         $this->assertArrayHasKey($path, $twigConfig[0]['paths']);
+
+        $this->assertContainerBuilderHasService('pagerfanta.serializer.normalizer');
     }
 
     public function testContainerIsLoadedWithDefaultConfigurationWhenJMSSerializerBundleIsInstalled(): void
@@ -208,6 +212,7 @@ final class BabDevPagerfantaExtensionTest extends AbstractExtensionTestCase
         }
 
         $this->assertContainerBuilderHasService('pagerfanta.serializer.handler');
+        $this->assertContainerBuilderHasService('pagerfanta.serializer.normalizer');
     }
 
     public function testContainerIsLoadedWhenBundleIsConfiguredWithCustomExceptionStrategies(): void

--- a/Tests/Serializer/Handler/PagerfantaHandlerTest.php
+++ b/Tests/Serializer/Handler/PagerfantaHandlerTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\Tests\Serializer\Handler;
+
+use BabDev\PagerfantaBundle\Serializer\Handler\PagerfantaHandler;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
+use Pagerfanta\Adapter\NullAdapter;
+use Pagerfanta\Pagerfanta;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class PagerfantaHandlerTest extends TestCase
+{
+    public function testSerializeToJson(): void
+    {
+        $pager = new Pagerfanta(
+            new NullAdapter(25)
+        );
+
+        $expectedResultArray = [
+            'items' => $pager->getCurrentPageResults(),
+            'pagination' => [
+                'current_page' => $pager->getCurrentPage(),
+                'has_previous_page' => $pager->hasPreviousPage(),
+                'has_next_page' => $pager->hasNextPage(),
+                'per_page' => $pager->getMaxPerPage(),
+                'total_items' => $pager->getNbResults(),
+                'total_pages' => $pager->getNbPages(),
+            ],
+        ];
+
+        /** @var SerializationContext&MockObject $context */
+        $context = $this->createMock(SerializationContext::class);
+
+        /** @var SerializationVisitorInterface&MockObject $visitor */
+        $visitor = $this->createMock(SerializationVisitorInterface::class);
+        $visitor->expects($this->once())
+            ->method('visitArray')
+            ->with($this->isType('array'), [])
+            ->willReturn($expectedResultArray);
+
+        $this->assertEquals(
+            $expectedResultArray,
+            (new PagerfantaHandler())->serializeToJson($visitor, $pager, [], $context)
+        );
+    }
+}

--- a/Tests/Serializer/Normalizer/PagerfantaNormalizerTest.php
+++ b/Tests/Serializer/Normalizer/PagerfantaNormalizerTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace BabDev\PagerfantaBundle\Tests\Serializer\Normalizer;
+
+use BabDev\PagerfantaBundle\Serializer\Normalizer\PagerfantaNormalizer;
+use Pagerfanta\Adapter\NullAdapter;
+use Pagerfanta\Pagerfanta;
+use Pagerfanta\PagerfantaInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+final class PagerfantaNormalizerTest extends TestCase
+{
+    public function testNormalize(): void
+    {
+        $pager = new Pagerfanta(
+            new NullAdapter(25)
+        );
+
+        $expectedResultArray = [
+            'items' => $pager->getCurrentPageResults(),
+            'pagination' => [
+                'current_page' => $pager->getCurrentPage(),
+                'has_previous_page' => $pager->hasPreviousPage(),
+                'has_next_page' => $pager->hasNextPage(),
+                'per_page' => $pager->getMaxPerPage(),
+                'total_items' => $pager->getNbResults(),
+                'total_pages' => $pager->getNbPages(),
+            ],
+        ];
+
+        $this->assertEquals(
+            $expectedResultArray,
+            (new PagerfantaNormalizer())->normalize($pager)
+        );
+    }
+
+    public function testNormalizeOnlyAcceptsPagerfantaInstances(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('The object must be an instance of "%s".', PagerfantaInterface::class));
+
+        (new PagerfantaNormalizer())->normalize(new \stdClass());
+    }
+
+    public function dataSupportsNormalization(): \Generator
+    {
+        yield 'Supported' => [new Pagerfanta(new NullAdapter(25)), true];
+        yield 'Not Supported' => [new \stdClass(), false];
+    }
+
+    /**
+     * @dataProvider dataSupportsNormalization
+     */
+    public function testSupportsNormalization($data, bool $supported): void
+    {
+        $this->assertSame($supported, (new PagerfantaNormalizer())->supportsNormalization($data));
+    }
+
+    public function testHasCacheableSupportsMethod(): void
+    {
+        $this->assertTrue((new PagerfantaNormalizer())->hasCacheableSupportsMethod());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
     "require-dev": {
         "doctrine/annotations": "^1.8",
         "friendsofphp/php-cs-fixer": "^2.16",
+        "jms/serializer": "^3.0",
+        "jms/serializer-bundle": "^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpstan/extension-installer": "^1.0.3",
         "phpstan/phpstan": "^0.12.37",
@@ -34,6 +36,7 @@
         "white-october/pagerfanta-bundle": "*"
     },
     "suggest": {
+        "jms/serializer-bundle": "To use the Pagerfanta class with the JMS Serializer",
         "symfony/translation": "To use the Pagerfanta views with translation support",
         "twig/twig": "To integrate Pagerfanta with Twig through extensions"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "phpstan/phpstan-phpunit": "^0.12.16",
         "phpstan/phpstan-symfony": "^0.12.7",
         "phpunit/phpunit": "^8.5 || ^9.0",
+        "symfony/serializer": "^3.4 || ^4.4 || ^5.1",
         "symfony/twig-bridge": "^3.4 || ^4.4 || ^5.1",
         "symfony/twig-bundle": "^3.4 || ^4.4 || ^5.1",
         "symfony/translation": "^3.4 || ^4.4 || ^5.1",
@@ -37,6 +38,7 @@
     },
     "suggest": {
         "jms/serializer-bundle": "To use the Pagerfanta class with the JMS Serializer",
+        "symfony/serializer": "To use the Pagerfanta class with the Symfony Serializer",
         "symfony/translation": "To use the Pagerfanta views with translation support",
         "twig/twig": "To integrate Pagerfanta with Twig through extensions"
     },

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,4 +7,5 @@
 - [Adding Views](/open-source/packages/pagerfantabundle/docs/2.x/adding-views)
 - [Retrieving Views](/open-source/packages/pagerfantabundle/docs/2.x/retrieving-views)
 - [Reusable Pagerfanta Configurations](/open-source/packages/pagerfantabundle/docs/2.x/reusing-options)
+- [Serializer](/open-source/packages/pagerfantabundle/docs/2.x/serializer)
 - [Configuring The Bundle](/open-source/packages/pagerfantabundle/docs/2.x/configuring-the-bundle)

--- a/docs/serializer.md
+++ b/docs/serializer.md
@@ -1,0 +1,63 @@
+# Serializer
+
+<div class="docs-note docs-note--new-feature">Serialization support was introduced in PagerfantaBundle 2.7.</div>
+
+The PagerfantaBundle provides support for serializing `Pagerfanta/Pagerfanta` instances using either the [Symfony Serializer component](https://symfony.com/doc/current/components/serializer.html) or the [JMS Serializer](https://jmsyst.com/libs/serializer) (note, the `JMSSerializerBundle` must be installed to enable the serialization handler for the JMS serializer).
+
+Below is an example of building a JSON response in a controller using the Symfony Serializer:
+
+```php
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\BlogPost;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
+use Pagerfanta\Pagerfanta;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class PostController extends AbstractController
+{
+    /**
+     * @Route("/api/posts", name="app_api_post_list", methods={"GET"})
+     */
+    public function apiPostList(): JsonResponse
+    {
+        $queryBuilder = $this->get('doctrine')->getRepository(BlogPost::class)->createBlogListQueryBuilder();
+
+        $pagerfanta = new Pagerfanta(
+            new QueryAdapter($queryBuilder)
+        );
+
+        return $this->json($pagerfanta);
+    }
+}
+```
+
+Below is an example of how a `Pagerfanta\Pagerfanta` instance is serialized into JSON format (note the `items` array is a simplified example, it will be an array of items based on your serializer configuration):
+
+```json
+{
+    "items": [
+        {
+            "id": 1
+        },
+        {
+            "id": 2
+        },
+        {
+            "id": 3
+        }
+    ],
+    "pagination": {
+        "current_page": 1,
+        "has_previous_page": false,
+        "has_next_page": true,
+        "per_page": 10,
+        "total_items": 35,
+        "total_pages": 4
+    }
+}
+```


### PR DESCRIPTION
Fixes #14

Adds support for both the Symfony Serializer and JMS Serializer, this creates first class support for using Pagerfanta in an API context by making it easy to pass a `Pagerfanta\Pagerfanta` instance through to a serializer.  In both instances, only support for normalization/serialization is included; the API won't support denormalization/deserialization (hopefully for obvious reasons).  For the JMS Serializer, right now it's only supporting encoding into JSON because that is what I'm personally using, but if someone wants to add XML support it will be greatly welcome.