### PR TITLE
Fix iterator serialization

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -4,7 +4,7 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHPUnit75Migration:risky' => true,
+        '@PHPUnit84Migration:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
         'blank_line_after_opening_tag' => false,
         'declare_strict_types' => true,
@@ -12,6 +12,7 @@ return PhpCsFixer\Config::create()
         'linebreak_after_opening_tag' => false,
         'no_superfluous_phpdoc_tags' => ['remove_inheritdoc' => true],
         'ordered_imports' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
         'protected_to_private' => true,
         'void_return' => true,
     ])

--- a/src/Serializer/Normalizer/PagerfantaNormalizer.php
+++ b/src/Serializer/Normalizer/PagerfantaNormalizer.php
@@ -5,10 +5,14 @@ namespace BabDev\PagerfantaBundle\Serializer\Normalizer;
 use Pagerfanta\PagerfantaInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-final class PagerfantaNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
+final class PagerfantaNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface, NormalizerAwareInterface
 {
+    use NormalizerAwareTrait;
+
     /**
      * @param mixed $object Object to normalize
      *
@@ -23,7 +27,7 @@ final class PagerfantaNormalizer implements NormalizerInterface, CacheableSuppor
         }
 
         return [
-            'items' => iterator_to_array($object),
+            'items' => $this->normalizer->normalize($object->getIterator(), $format, $context),
             'pagination' => [
                 'current_page' => $object->getCurrentPage(),
                 'has_previous_page' => $object->hasPreviousPage(),

--- a/src/Serializer/Normalizer/PagerfantaNormalizer.php
+++ b/src/Serializer/Normalizer/PagerfantaNormalizer.php
@@ -23,7 +23,7 @@ final class PagerfantaNormalizer implements NormalizerInterface, CacheableSuppor
         }
 
         return [
-            'items' => $object->getCurrentPageResults(),
+            'items' => iterator_to_array($object),
             'pagination' => [
                 'current_page' => $object->getCurrentPage(),
                 'has_previous_page' => $object->hasPreviousPage(),

--- a/tests/DependencyInjection/BabDevPagerfantaExtensionTest.php
+++ b/tests/DependencyInjection/BabDevPagerfantaExtensionTest.php
@@ -67,7 +67,7 @@ final class BabDevPagerfantaExtensionTest extends AbstractExtensionTestCase
     public function testContainerIsLoadedWithDefaultConfigurationWhenTwigBundleIsInstalled(): void
     {
         if (!class_exists(PagerfantaExtension::class)) {
-            $this->markTestSkipped('Test requires Twig');
+            self::markTestSkipped('Test requires Twig');
         }
 
         $this->container->registerExtension(new TwigExtension());
@@ -141,12 +141,12 @@ final class BabDevPagerfantaExtensionTest extends AbstractExtensionTestCase
         $refl = new \ReflectionClass(PagerfantaExtension::class);
 
         if (false === $refl->getFileName()) {
-            $this->fail(sprintf('Could not reflect "%s"', PagerfantaExtension::class));
+            self::fail(sprintf('Could not reflect "%s"', PagerfantaExtension::class));
         }
 
         $path = \dirname($refl->getFileName(), 2).'/templates/';
 
-        $this->assertArrayHasKey($path, $twigConfig[0]['paths']);
+        self::assertArrayHasKey($path, $twigConfig[0]['paths']);
 
         $this->assertContainerBuilderHasService('pagerfanta.serializer.normalizer');
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -12,7 +12,7 @@ final class ConfigurationTest extends TestCase
     {
         $config = (new Processor())->processConfiguration(new Configuration(), []);
 
-        $this->assertEquals(self::getBundleDefaultConfig(), $config);
+        self::assertEquals(self::getBundleDefaultConfig(), $config);
     }
 
     public function testConfigWithCustomDefaultView(): void
@@ -23,7 +23,7 @@ final class ConfigurationTest extends TestCase
 
         $config = (new Processor())->processConfiguration(new Configuration(), [$extraConfig]);
 
-        $this->assertEquals(
+        self::assertEquals(
             array_merge(self::getBundleDefaultConfig(), $extraConfig),
             $config
         );
@@ -37,7 +37,7 @@ final class ConfigurationTest extends TestCase
 
         $config = (new Processor())->processConfiguration(new Configuration(), [$extraConfig]);
 
-        $this->assertEquals(
+        self::assertEquals(
             array_merge(self::getBundleDefaultConfig(), $extraConfig),
             $config
         );
@@ -54,7 +54,7 @@ final class ConfigurationTest extends TestCase
 
         $config = (new Processor())->processConfiguration(new Configuration(), [$extraConfig]);
 
-        $this->assertEquals(
+        self::assertEquals(
             array_merge(self::getBundleDefaultConfig(), $extraConfig),
             $config
         );

--- a/tests/EventListener/ConvertNotValidCurrentPageToNotFoundListenerTest.php
+++ b/tests/EventListener/ConvertNotValidCurrentPageToNotFoundListenerTest.php
@@ -25,8 +25,8 @@ final class ConvertNotValidCurrentPageToNotFoundListenerTest extends TestCase
 
         (new ConvertNotValidCurrentPageToNotFoundListener())->onKernelException($event);
 
-        $this->assertInstanceOf(NotFoundHttpException::class, $event->getThrowable());
-        $this->assertSame($exception, $event->getThrowable()->getPrevious());
+        self::assertInstanceOf(NotFoundHttpException::class, $event->getThrowable());
+        self::assertSame($exception, $event->getThrowable()->getPrevious());
     }
 
     public function testListenerDoesNotConvertUnknownExceptionForEvent(): void
@@ -42,6 +42,6 @@ final class ConvertNotValidCurrentPageToNotFoundListenerTest extends TestCase
 
         (new ConvertNotValidCurrentPageToNotFoundListener())->onKernelException($event);
 
-        $this->assertSame($exception, $event->getThrowable());
+        self::assertSame($exception, $event->getThrowable());
     }
 }

--- a/tests/EventListener/ConvertNotValidMaxPerPageToNotFoundListenerTest.php
+++ b/tests/EventListener/ConvertNotValidMaxPerPageToNotFoundListenerTest.php
@@ -25,8 +25,8 @@ final class ConvertNotValidMaxPerPageToNotFoundListenerTest extends TestCase
 
         (new ConvertNotValidMaxPerPageToNotFoundListener())->onKernelException($event);
 
-        $this->assertInstanceOf(NotFoundHttpException::class, $event->getThrowable());
-        $this->assertSame($exception, $event->getThrowable()->getPrevious());
+        self::assertInstanceOf(NotFoundHttpException::class, $event->getThrowable());
+        self::assertSame($exception, $event->getThrowable()->getPrevious());
     }
 
     public function testListenerDoesNotConvertUnknownExceptionForEvent(): void
@@ -42,6 +42,6 @@ final class ConvertNotValidMaxPerPageToNotFoundListenerTest extends TestCase
 
         (new ConvertNotValidMaxPerPageToNotFoundListener())->onKernelException($event);
 
-        $this->assertSame($exception, $event->getThrowable());
+        self::assertSame($exception, $event->getThrowable());
     }
 }

--- a/tests/RouteGenerator/RequestAwareRouteGeneratorFactoryTest.php
+++ b/tests/RouteGenerator/RequestAwareRouteGeneratorFactoryTest.php
@@ -50,7 +50,7 @@ final class RequestAwareRouteGeneratorFactoryTest extends TestCase
 
         $this->requestStack->push($request);
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             RouteGeneratorInterface::class,
             $this->createFactory(true)->create()
         );
@@ -67,7 +67,7 @@ final class RequestAwareRouteGeneratorFactoryTest extends TestCase
         $this->requestStack->push($masterRequest);
         $this->requestStack->push($subRequest);
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             RouteGeneratorInterface::class,
             $this->createFactory(true)->create(['routeName' => 'pagerfanta_view'])
         );

--- a/tests/RouteGenerator/RouterAwareRouteGeneratorTest.php
+++ b/tests/RouteGenerator/RouterAwareRouteGeneratorTest.php
@@ -43,7 +43,7 @@ final class RouterAwareRouteGeneratorTest extends TestCase
     {
         $generator = new RouterAwareRouteGenerator($this->createRouter(), ['routeName' => 'pagerfanta_view']);
 
-        $this->assertSame('/pagerfanta-view?page=1', $generator(1));
+        self::assertSame('/pagerfanta-view?page=1', $generator(1));
     }
 
     public function testARouteIsGeneratedWithFirstPageOmitted(): void
@@ -54,7 +54,7 @@ final class RouterAwareRouteGeneratorTest extends TestCase
             ['routeName' => 'pagerfanta_view', 'omitFirstPage' => true]
         );
 
-        $this->assertSame('/pagerfanta-view', $generator(1));
+        self::assertSame('/pagerfanta-view', $generator(1));
     }
 
     public function testARouteIsGeneratedWithACustomPageParameter(): void
@@ -64,7 +64,7 @@ final class RouterAwareRouteGeneratorTest extends TestCase
             ['routeName' => 'pagerfanta_view', 'pageParameter' => '[custom_page]']
         );
 
-        $this->assertSame('/pagerfanta-view?custom_page=1', $generator(1));
+        self::assertSame('/pagerfanta-view?custom_page=1', $generator(1));
     }
 
     public function testARouteIsGeneratedWithAdditionalParameters(): void
@@ -75,7 +75,7 @@ final class RouterAwareRouteGeneratorTest extends TestCase
             ['routeName' => 'pagerfanta_view', 'routeParams' => ['hello' => 'world']]
         );
 
-        $this->assertSame('/pagerfanta-view?hello=world&page=1', $generator(1));
+        self::assertSame('/pagerfanta-view?hello=world&page=1', $generator(1));
     }
 
     public function testARouteIsGeneratedWithAnAbsoluteUrl(): void
@@ -85,7 +85,7 @@ final class RouterAwareRouteGeneratorTest extends TestCase
             ['routeName' => 'pagerfanta_view', 'referenceType' => UrlGeneratorInterface::ABSOLUTE_URL]
         );
 
-        $this->assertSame('http://localhost/pagerfanta-view?page=1', $generator(1));
+        self::assertSame('http://localhost/pagerfanta-view?page=1', $generator(1));
     }
 
     public function testARouteIsNotGeneratedWhenTheRouteNameParameterIsMissing(): void

--- a/tests/Serializer/Handler/PagerfantaHandlerTest.php
+++ b/tests/Serializer/Handler/PagerfantaHandlerTest.php
@@ -35,12 +35,12 @@ final class PagerfantaHandlerTest extends TestCase
 
         /** @var SerializationVisitorInterface&MockObject $visitor */
         $visitor = $this->createMock(SerializationVisitorInterface::class);
-        $visitor->expects($this->once())
+        $visitor->expects(self::once())
             ->method('visitArray')
-            ->with($this->isType('array'), [])
+            ->with(self::isType('array'), [])
             ->willReturn($expectedResultArray);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResultArray,
             (new PagerfantaHandler())->serializeToJson($visitor, $pager, [], $context)
         );

--- a/tests/Serializer/Normalizer/PagerfantaNormalizerTest.php
+++ b/tests/Serializer/Normalizer/PagerfantaNormalizerTest.php
@@ -32,7 +32,7 @@ final class PagerfantaNormalizerTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResultArray,
             (new PagerfantaNormalizer())->normalize($pager)
         );
@@ -53,34 +53,26 @@ final class PagerfantaNormalizerTest extends TestCase
     }
 
     /**
-     * @param mixed $data
-     *
      * @dataProvider dataSupportsNormalization
      */
     public function testSupportsNormalization($data, bool $supported): void
     {
-        $this->assertSame($supported, (new PagerfantaNormalizer())->supportsNormalization($data));
+        self::assertSame($supported, (new PagerfantaNormalizer())->supportsNormalization($data));
     }
 
     public function testHasCacheableSupportsMethod(): void
     {
-        $this->assertTrue((new PagerfantaNormalizer())->hasCacheableSupportsMethod());
+        self::assertTrue((new PagerfantaNormalizer())->hasCacheableSupportsMethod());
     }
 
     public function testIteSerializesIterableData(): void
     {
         $serializer = new Serializer([new PagerfantaNormalizer()], [new JsonEncoder()]);
-        $generator = static function (): iterable {
-            yield '1';
-            yield '2';
-            yield '3';
-            yield '4';
-            yield '5';
-        };
-        $pager = new Pagerfanta(new FixedAdapter(5, $generator()));
+        $items = ['1', '2', '3', '4', '5'];
+        $pager = new Pagerfanta(new FixedAdapter(5, new \ArrayIterator($items)));
 
         $expectedResultArray = [
-            'items' => iterator_to_array($pager->getCurrentPageResults()),
+            'items' => $items,
             'pagination' => [
                 'current_page' => $pager->getCurrentPage(),
                 'has_previous_page' => $pager->hasPreviousPage(),
@@ -91,6 +83,6 @@ final class PagerfantaNormalizerTest extends TestCase
             ],
         ];
 
-        self::assertSame($expectedResultArray, \json_decode($serializer->serialize($pager, 'json'), true));
+        self::assertSame($expectedResultArray, json_decode($serializer->serialize($pager, 'json'), true));
     }
 }

--- a/tests/Serializer/Normalizer/PagerfantaNormalizerTest.php
+++ b/tests/Serializer/Normalizer/PagerfantaNormalizerTest.php
@@ -8,7 +8,6 @@ use Pagerfanta\Adapter\NullAdapter;
 use Pagerfanta\Pagerfanta;
 use Pagerfanta\PagerfantaInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Serializer;
 
@@ -31,11 +30,9 @@ final class PagerfantaNormalizerTest extends TestCase
                 'total_pages' => $pager->getNbPages(),
             ],
         ];
+        $serializer = new Serializer([new PagerfantaNormalizer()]);
 
-        self::assertEquals(
-            $expectedResultArray,
-            (new PagerfantaNormalizer())->normalize($pager)
-        );
+        self::assertEquals($expectedResultArray, $serializer->normalize($pager));
     }
 
     public function testNormalizeOnlyAcceptsPagerfantaInstances(): void
@@ -67,7 +64,7 @@ final class PagerfantaNormalizerTest extends TestCase
 
     public function testIteSerializesIterableData(): void
     {
-        $serializer = new Serializer([new PagerfantaNormalizer()], [new JsonEncoder()]);
+        $serializer = new Serializer([new PagerfantaNormalizer()]);
         $items = ['1', '2', '3', '4', '5'];
         $pager = new Pagerfanta(new FixedAdapter(5, new \ArrayIterator($items)));
 
@@ -83,6 +80,6 @@ final class PagerfantaNormalizerTest extends TestCase
             ],
         ];
 
-        self::assertSame($expectedResultArray, json_decode($serializer->serialize($pager, 'json'), true));
+        self::assertSame($expectedResultArray, $serializer->normalize($pager));
     }
 }

--- a/tests/View/TwigViewIntegrationTest.php
+++ b/tests/View/TwigViewIntegrationTest.php
@@ -412,7 +412,7 @@ final class TwigViewIntegrationTest extends TestCase
 
         $this->requestStack->push($request);
 
-        $this->assertNotEmpty(
+        self::assertNotEmpty(
             (new TwigView($this->twig))->render(
                 $this->createPagerfanta(),
                 (new RequestAwareRouteGeneratorFactory($this->router, $this->requestStack, $this->propertyAccessor))->create()
@@ -483,7 +483,7 @@ final class TwigViewIntegrationTest extends TestCase
 
     private function assertViewOutputMatches(string $view, string $expected): void
     {
-        $this->assertSame($this->removeWhitespacesBetweenTags($expected), $view);
+        self::assertSame($this->removeWhitespacesBetweenTags($expected), $view);
     }
 
     private function removeWhitespacesBetweenTags(string $string): string


### PR DESCRIPTION
This PR fixes serialization issue when using Symfony Serializer and a provider returning a non-array `iterable`.
Fixes #35 

I've also added a new rule for PHP CS Fixer to call PHPUnit `assert*()` methods statically.

~~Using `iterator_to_array($object)` is enough because `Pagerfanta` implements `IteratorAggregate`~~
Above ignores the context (eg. serialization groups). Fixed in further commits.

Symfony Serializer injects itself to Normalizers implementing `Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface` which allows to run nested normalization there.

I think we need some extra test to make sure the context (groups, etc) is passed to the underlying normalizer.