### PR TITLE
[v3.x] use strict vars for Twig tests

### DIFF
--- a/templates/macros.html.twig
+++ b/templates/macros.html.twig
@@ -1,5 +1,5 @@
 {%- macro resolve_previous_page_message(options) -%}
-    {%- if options['prev_message'] is defined -%}
+    {%- if options['prev_message'] is empty -%}
         {{- options['prev_message'] -}}
     {%- else -%}
         {{- 'Previous'|trans([], 'pagerfanta') -}}

--- a/templates/macros.html.twig
+++ b/templates/macros.html.twig
@@ -1,5 +1,5 @@
 {%- macro resolve_previous_page_message(options) -%}
-    {%- if options['prev_message'] is empty -%}
+    {%- if options['prev_message'] is defined -%}
         {{- options['prev_message'] -}}
     {%- else -%}
         {{- 'Previous'|trans([], 'pagerfanta') -}}

--- a/tests/View/TwigViewIntegrationTest.php
+++ b/tests/View/TwigViewIntegrationTest.php
@@ -75,7 +75,10 @@ final class TwigViewIntegrationTest extends TestCase
         $filesystemLoader->addPath(__DIR__.'/../../templates', 'BabDevPagerfanta');
         $filesystemLoader->addPath($path, 'Pagerfanta');
 
-        $this->twig = new Environment(new ChainLoader([new ArrayLoader(['integration.html.twig' => '{{ pagerfanta(pager, options) }}']), $filesystemLoader]));
+        $loader = new ChainLoader(
+            [new ArrayLoader(['integration.html.twig' => '{{ pagerfanta(pager, options) }}']), $filesystemLoader]
+        );
+        $this->twig = new Environment($loader, ['strict_variables' => false]);
         $this->twig->addExtension(new PagerfantaExtension());
         $this->twig->addExtension(new TranslationExtension($this->createTranslator()));
         $this->twig->addRuntimeLoader($this->createRuntimeLoader());


### PR DESCRIPTION
This PR sets Twig's `strict_variables` to `true` (by default Symfony enables this option when `kernel.debug` is `true`). The macro is already fixed so the change is to demonstrate the test failure, but let's keep it strict to avoid any regressions in the future.

This proves #8 is fixed.